### PR TITLE
Fixes shared state issue.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,14 +4,6 @@ var intersectRaySphere = require('ray-sphere-intersection')
 var intersectRayBox = require('ray-aabb-intersection')
 var copy3 = require('gl-vec3/copy')
 
-var tmpTriangle = [
-  [0, 0, 0],
-  [0, 0, 0],
-  [0, 0, 0]
-]
-
-var tmp3 = [0, 0, 0]
-
 module.exports = Ray
 function Ray (origin, direction) {
   this.origin = origin || [ 0, 0, 0 ]
@@ -35,22 +27,31 @@ Ray.prototype.clone = function () {
 }
 
 Ray.prototype.intersectsSphere = function (center, radius) {
+  var tmp3 = [0, 0, 0]
   return intersectRaySphere(tmp3, this.origin, this.direction, center, radius)
 }
 
 Ray.prototype.intersectsPlane = function (normal, distance) {
+  var tmp3 = [0, 0, 0]
   return intersectRayPlane(tmp3, this.origin, this.direction, normal, distance)
 }
 
 Ray.prototype.intersectsTriangle = function (triangle) {
+  var tmp3 = [0, 0, 0]
   return intersectRayTriangle(tmp3, this.origin, this.direction, triangle)
 }
 
 Ray.prototype.intersectsBox = function (aabb) {
+  var tmp3 = [0, 0, 0]
   return intersectRayBox(tmp3, this.origin, this.direction, aabb)
 }
 
 Ray.prototype.intersectsTriangleCell = function (cell, positions) {
+  var tmpTriangle = [
+    [0, 0, 0],
+    [0, 0, 0],
+    [0, 0, 0]
+  ]
   var a = cell[0], b = cell[1], c = cell[2]
   tmpTriangle[0] = positions[a]
   tmpTriangle[1] = positions[b]

--- a/test.js
+++ b/test.js
@@ -23,3 +23,60 @@ test('a high-level picking ray helper for 3D intersection', function(t) {
 
   t.end()
 })
+
+test.only('methods do not share state between calls', function(t) {
+  t.plan(5)
+
+  // All the following values are chosen such that x and xCopy are non-null.
+  // This achieves that the functions (indirectly, through subcalls) call
+  // gl-matrix/vec3.add or similarly *mutate* their first parameter; this
+  // mutation triggered the original problem.
+  var ray = new Ray([0, 0, 0], [1, 1, 1])
+
+  var a = ray.intersectsSphere([0, 0, 0], 1)
+  var aCopy = [a[0], a[1], a[2]]
+  ray.intersectsSphere([0, 0, 0], 2)
+  t.deepEqual(a, aCopy)
+
+  var b = ray.intersectsPlane([0, 0, 1], -1)
+  var bCopy = [b[0], b[1], b[2]]
+  ray.intersectsPlane([0, 0, 1], -2)
+  t.deepEqual(b, bCopy)
+
+  var c = ray.intersectsTriangle([
+    [0, 0, 1],
+    [0, 1, 0],
+    [1, 0, 0]
+  ])
+  var cCopy = [c[0], c[1], c[2]]
+  ray.intersectsTriangle([
+    [0, 0, 2],
+    [0, 2, 0],
+    [2, 0, 0]
+  ])
+  t.deepEqual(c, cCopy)
+
+  var d = ray.intersectsBox([
+    [1, 1, 1],
+    [2, 2, 2]
+  ])
+  var dCopy = [d[0], d[1], d[2]]
+  ray.intersectsBox([
+    [3, 3, 3],
+    [4, 4, 4]
+  ])
+  t.deepEqual(d, dCopy)
+
+  var e = ray.intersectsTriangleCell([0, 1, 2], [
+    [0, 0, 1],
+    [0, 1, 0],
+    [1, 0, 0]
+  ])
+  var eCopy = [e[0], e[1], e[2]]
+  ray.intersectsTriangleCell([0, 1, 2], [
+    [0, 0, 2],
+    [0, 2, 0],
+    [2, 0, 0]
+  ])
+  t.deepEqual(e, eCopy)
+})


### PR DESCRIPTION
The `tmp3` and `tmpTriangle` variable were shared global state, and they were returned by reference in some of the functions. This caused unexpected behavior when doing something like this:

```js
  var ray = new Ray([0, 0, 0], [1, 1, 1])
  var b = ray.intersectsPlane([0, 0, 1], -1)

  // anywhere else within the same project
  ray.intersectsPlane([0, 0, 1], -2) // changes the b from above!
```

I fixed this by making `tmp3` and `tmpTriangle` local variables and added tests for this type of bug.

